### PR TITLE
Enabling named export alongside default one

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ npm install apple-news-client
 TypeScript
 
 ```typescript
-import AppleNewsClient from "apple-news-client";
+import { AppleNewsClient } from "apple-news-client";
 
 const client: AppleNewsClient = new AppleNewsClient({
     apiId: "<API_ID>",

--- a/index.js
+++ b/index.js
@@ -19,4 +19,7 @@
  *****************************************************************/
 const AppleNewsClient = require("./lib").default;
 
-module.exports = AppleNewsClient;
+module.exports = {
+    default: AppleNewsClient,
+    AppleNewsClient
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,7 +16,7 @@ export type ClientRequestCallback = (...args: any[]) => any;
  * The Apple News Client class. Exposing an instance of the client
  * is necessary for accessing the various request types.
  */
-export default class AppleNewsClient {
+export class AppleNewsClient {
     /**
      * @property {string} apiId - The Apple News API Key Id.
      * @private
@@ -280,3 +280,5 @@ export default class AppleNewsClient {
         );
     }
 }
+
+export default AppleNewsClient;


### PR DESCRIPTION
- couldn't use `import AppleNewsClient from "apple-news-client";` as I was getting an error that AppleNewsClient.default is not a constructor
- could only use const ... = export which isn't types
- console.log of  AppleNewsClient before instantiation returned `undefined`
- updated exports to both maintain backward compatibility for those using default import syntax and allow for named import as well
- tested both imports after update

 